### PR TITLE
Update Flickr4Java/src/com/flickr4java/flickr/REST.java

### DIFF
--- a/Flickr4Java/src/com/flickr4java/flickr/REST.java
+++ b/Flickr4Java/src/com/flickr4java/flickr/REST.java
@@ -264,9 +264,11 @@ public class REST extends Transport {
 
         RequestContext requestContext = RequestContext.getRequestContext();
         Auth auth = requestContext.getAuth();
-        Token requestToken = new Token(auth.getToken(), auth.getTokenSecret());
-        OAuthService service = createOAuthService(parameters, sharedSecret);
-        service.signRequest(requestToken, request);
+        if (auth != null){
+            Token requestToken = new Token(auth.getToken(), auth.getTokenSecret());
+            OAuthService service = createOAuthService(parameters, sharedSecret);
+            service.signRequest(requestToken, request);   
+        }
 
         if (multipart) {
             // Ensure all parameters (including oauth) are added to payload so signature matches


### PR DESCRIPTION
Allow unsigned requests if auth is not set. This is useful, for example, when getting a list of (public) sets and photos from another Flickr user.
