### PR TITLE
Make sure buffer is offset correctly when written to stream in REST.java

### DIFF
--- a/Flickr4Java/src/com/flickr4java/flickr/REST.java
+++ b/Flickr4Java/src/com/flickr4java/flickr/REST.java
@@ -405,10 +405,9 @@ public class REST extends Transport {
             InputStream in = (InputStream) value;
             byte[] buf = new byte[512];
 
-            @SuppressWarnings("unused")
             int res = -1;
             while ((res = in.read(buf)) != -1) {
-                buffer.write(buf);
+                buffer.write(buf,0,res);
             }
             buffer.write(("\r\n" + "--" + boundary + "\r\n").getBytes(CHARSET_NAME));
         } else if (value instanceof byte[]) {


### PR DESCRIPTION
Make sure we offset the buffer write with the number of bytes read from the input. 

I'm confused as to how this seems to work at the moment. Are we just lucky?
