### PR TITLE
Send api_key when using no authentication

### DIFF
--- a/Flickr4Java/src/main/java/com/flickr4java/flickr/REST.java
+++ b/Flickr4Java/src/main/java/com/flickr4java/flickr/REST.java
@@ -158,6 +158,8 @@ public class REST extends Transport {
             Token requestToken = new Token(auth.getToken(), auth.getTokenSecret());
             OAuthService service = createOAuthService(parameters, apiKey, sharedSecret);
             service.signRequest(requestToken, request);
+        } else {
+            request.addQuerystringParameter("api_key", apiKey);
         }
 
         if (Flickr.debugRequest) {


### PR DESCRIPTION
I noticed that Flickr4java doesn't work when I want to execute call without authentication. I have no idea if my change is in the appropriate location, but it's central enough to affect all the calls we do.
