### PR TITLE
PhotosetInterface.getInfo() should be a GET request and not a POST request

### DIFF
--- a/Flickr4Java/src/main/java/com/flickr4java/flickr/photosets/PhotosetsInterface.java
+++ b/Flickr4Java/src/main/java/com/flickr4java/flickr/photosets/PhotosetsInterface.java
@@ -262,7 +262,7 @@ public class PhotosetsInterface {
 
         parameters.put("photoset_id", photosetId);
 
-        Response response = transportAPI.post(transportAPI.getPath(), parameters, apiKey, sharedSecret);
+        Response response = transportAPI.get(transportAPI.getPath(), parameters, apiKey, sharedSecret);
         if (response.isError()) {
             throw new FlickrException(response.getErrorCode(), response.getErrorMessage());
         }


### PR DESCRIPTION
This fixes "100: Invalid API Key (Key has invalid format)" related to PhotosetInterface.getInfo().

This is relates to commentaries Issue #94
