### PR TITLE
Reinstated "views" element

### DIFF
--- a/Flickr4Java/src/main/java/com/flickr4java/flickr/photos/PhotoUtils.java
+++ b/Flickr4Java/src/main/java/com/flickr4java/flickr/photos/PhotoUtils.java
@@ -78,6 +78,7 @@ public final class PhotoUtils {
         photo.setMedia(photoElement.getAttribute("media"));
         photo.setMediaStatus(photoElement.getAttribute("media_status"));
         photo.setPathAlias(photoElement.getAttribute("pathalias"));
+        photo.setViews(photoElement.getAttribute("views"));
         
         Element peopleElement = (Element) photoElement.getElementsByTagName("people").item(0);
         if(peopleElement != null){


### PR DESCRIPTION
Reinstate processing of "views" element (removal of deprecated tags already performed in Photos, possibly in the master branch. Sorry about that, I expected it to fork it...)
