### PR TITLE
Fix SAXParseException on REST.get call

### DIFF
--- a/Flickr4Java/src/main/java/com/flickr4java/flickr/REST.java
+++ b/Flickr4Java/src/main/java/com/flickr4java/flickr/REST.java
@@ -177,7 +177,7 @@ public class REST extends Transport {
 
             com.flickr4java.flickr.Response response = null;
             synchronized (mutex) {
-                String strXml = scribeResponse.getBody();
+                String strXml = scribeResponse.getBody().trim();
                 if (Flickr.debugStream) {
                     logger.debug(strXml);
                 }
@@ -300,7 +300,7 @@ public class REST extends Transport {
         try {
             com.flickr4java.flickr.Response response = null;
             synchronized (mutex) {
-                String strXml = scribeResponse.getBody();
+                String strXml = scribeResponse.getBody().trim();
                 if (Flickr.debugStream) {
                     logger.debug(strXml);
                 }


### PR DESCRIPTION
Trimming the response so it will be parsable even though is starts with leading whitespaces.
