### PR TITLE
Allow fetching json response from Flickr (for a few methods)

### DIFF
--- a/Flickr4Java/.gitignore
+++ b/Flickr4Java/.gitignore
@@ -11,3 +11,4 @@ Flickr4Java.iws
 .project
 .settings/
 bin/
+**rebel.xml

--- a/Flickr4Java/src/main/java/com/flickr4java/flickr/JSONResponse.java
+++ b/Flickr4Java/src/main/java/com/flickr4java/flickr/JSONResponse.java
@@ -1,0 +1,13 @@
+package com.flickr4java.flickr;
+
+/**
+ * An interface for a response object which carries json
+ */
+public interface JSONResponse {
+
+    /**
+     * Returns json as String
+     */
+    StringBuilder getBody();
+
+}

--- a/Flickr4Java/src/main/java/com/flickr4java/flickr/Transport.java
+++ b/Flickr4Java/src/main/java/com/flickr4java/flickr/Transport.java
@@ -8,7 +8,7 @@ import java.util.Map;
 /**
  * The abstract Transport class provides a common interface for transporting requests to the Flickr servers. Flickr offers several transport methods including
  * REST, SOAP and XML-RPC. Flickr4Java currently implements the REST transport and work is being done to include the SOAP transport.
- * 
+ *
  * @author Matt Ray
  * @author Anthony Eden
  */
@@ -26,7 +26,7 @@ public abstract class Transport {
     public static final String UPLOAD_API_HOST = "up.flickr.com";
 
     protected static final String DEFAULT_SCHEME = "https";
-    
+
     private String transportType;
 
     protected Class<?> responseClass;
@@ -36,7 +36,7 @@ public abstract class Transport {
     private String host;
 
     private int port = 443;
-    
+
     private String scheme;
 
     public String getHost() {
@@ -81,7 +81,7 @@ public abstract class Transport {
 
     /**
      * Invoke an HTTP GET request on a remote host. You must close the InputStream after you are done with.
-     * 
+     *
      * @param path
      *            The request path
      * @param parameters
@@ -94,8 +94,27 @@ public abstract class Transport {
     public abstract Response get(String path, Map<String, Object> parameters, String apiKey, String sharedSecret) throws FlickrException;
 
     /**
+     * Invoke an HTTP GET request on a remote host. You must close the InputStream after you are done with.
+     * While #get request for XML which is further processed to marshalize flickr-objects,
+     * this method makes sure the response contaisn json which could be passed to a client (JavaScript available).
+     *
+     * @param path
+     *            The request path
+     * @param parameters
+     *            The parameters (collection of Parameter objects)
+     * @param apiKey
+     * @param sharedSecret
+     * @return The Response
+     * @throws FlickrException
+     */
+    public abstract JSONResponse getJson(String path, Map<String, Object> parameters, String apiKey, String sharedSecret,boolean noJsonCallback) throws FlickrException;
+
+
+
+
+    /**
      * Invoke an HTTP POST request on a remote host.
-     * 
+     *
      * @param path
      *            The request path
      * @param parameters
@@ -109,7 +128,7 @@ public abstract class Transport {
 
     /**
      * Invoke an HTTP POST request on a remote host.
-     * 
+     *
      * @param path
      *            The request path
      * @param parameters
@@ -126,9 +145,9 @@ public abstract class Transport {
 
     /**
      * Invoke a non OAuth HTTP GET request on a remote host.
-     * 
+     *
      * This is only used for the Flickr OAuth methods checkToken and getAccessToken.
-     * 
+     *
      * @param path
      *            The request path
      * @param parameters

--- a/Flickr4Java/src/main/java/com/flickr4java/flickr/json/JSONResponseImpl.java
+++ b/Flickr4Java/src/main/java/com/flickr4java/flickr/json/JSONResponseImpl.java
@@ -1,0 +1,35 @@
+package com.flickr4java.flickr.json;
+
+import org.apache.log4j.Logger;
+import org.scribe.model.Response;
+
+import com.flickr4java.flickr.JSONResponse;
+import com.flickr4java.flickr.util.StringUtilities;
+
+/**
+ *
+ */
+public class JSONResponseImpl implements JSONResponse {
+
+    private static final Logger logger = Logger.getLogger(JSONResponseImpl.class);
+
+
+    private Response scribeResponse;
+    private StringBuilder body;
+
+    public JSONResponseImpl(Response scribeResponse){
+        this.scribeResponse = scribeResponse;
+        if(StringUtilities.isNotBlank(scribeResponse.getBody())){
+            body = new StringBuilder(scribeResponse.getBody());
+        }else{
+            body = new StringBuilder("");
+        }
+    }
+
+    @Override
+    public StringBuilder getBody() {
+        return body;
+    }
+
+
+}

--- a/Flickr4Java/src/main/java/com/flickr4java/flickr/photos/PhotosInterface.java
+++ b/Flickr4Java/src/main/java/com/flickr4java/flickr/photos/PhotosInterface.java
@@ -3,22 +3,6 @@
  */
 package com.flickr4java.flickr.photos;
 
-import com.flickr4java.flickr.FlickrException;
-import com.flickr4java.flickr.REST;
-import com.flickr4java.flickr.RequestContext;
-import com.flickr4java.flickr.Response;
-import com.flickr4java.flickr.Transport;
-import com.flickr4java.flickr.people.User;
-import com.flickr4java.flickr.photos.geo.GeoInterface;
-import com.flickr4java.flickr.util.IOUtilities;
-import com.flickr4java.flickr.util.StringUtilities;
-import com.flickr4java.flickr.util.XMLUtilities;
-
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
-
-import javax.imageio.ImageIO;
-
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.InputStream;
@@ -35,9 +19,26 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.imageio.ImageIO;
+
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import com.flickr4java.flickr.FlickrException;
+import com.flickr4java.flickr.JSONResponse;
+import com.flickr4java.flickr.REST;
+import com.flickr4java.flickr.RequestContext;
+import com.flickr4java.flickr.Response;
+import com.flickr4java.flickr.Transport;
+import com.flickr4java.flickr.people.User;
+import com.flickr4java.flickr.photos.geo.GeoInterface;
+import com.flickr4java.flickr.util.IOUtilities;
+import com.flickr4java.flickr.util.StringUtilities;
+import com.flickr4java.flickr.util.XMLUtilities;
+
 /**
  * Interface for working with Flickr Photos.
- * 
+ *
  * @author Anthony Eden
  * @version $Id: PhotosInterface.java,v 1.51 2010/07/20 20:11:16 x-mago Exp $
  */
@@ -120,7 +121,7 @@ public class PhotosInterface {
 
     /**
      * Get the geo interface.
-     * 
+     *
      * @return Access class to the flickr.photos.geo methods.
      */
     public synchronized GeoInterface getGeoInterface() {
@@ -132,9 +133,9 @@ public class PhotosInterface {
 
     /**
      * Add tags to a photo.
-     * 
+     *
      * This method requires authentication with 'write' permission.
-     * 
+     *
      * @param photoId
      *            The photo ID
      * @param tags
@@ -156,9 +157,9 @@ public class PhotosInterface {
 
     /**
      * Delete a photo from flickr.
-     * 
+     *
      * This method requires authentication with 'delete' permission.
-     * 
+     *
      * @param photoId
      * @throws FlickrException
      */
@@ -179,19 +180,19 @@ public class PhotosInterface {
 
     /**
      * Returns all visble sets and pools the photo belongs to.
-     * 
+     *
      * This method does not require authentication.
-     * 
+     *
      * @param photoId
      *            The photo to return information for.
      * @return a list of {@link PhotoContext} objects
      * @throws FlickrException
      */
     public PhotoAllContext getAllContexts(String photoId) throws FlickrException {
-    	PhotoSetList<PhotoSet> setList = new PhotoSetList<PhotoSet>();
-    	PoolList<Pool> poolList = new PoolList<Pool>();
-    	PhotoAllContext allContext = new PhotoAllContext();
-    	     
+        PhotoSetList<PhotoSet> setList = new PhotoSetList<PhotoSet>();
+        PoolList<Pool> poolList = new PoolList<Pool>();
+        PhotoAllContext allContext = new PhotoAllContext();
+
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("method", METHOD_GET_ALL_CONTEXTS);
 
@@ -203,44 +204,44 @@ public class PhotosInterface {
         }
         Collection<Element> photosElement = response.getPayloadCollection();
 
-    	for (Element setElement : photosElement) {
-    		if(setElement.getTagName().equals("set")){
-	            PhotoSet pset = new PhotoSet();
-	            pset.setTitle(setElement.getAttribute("title"));
-	            pset.setSecret(setElement.getAttribute("secret"));
-	            pset.setId(setElement.getAttribute("id"));
-	            pset.setFarm(setElement.getAttribute("farm"));
-	            pset.setPrimary(setElement.getAttribute("primary"));
-	            pset.setServer(setElement.getAttribute("server"));
-	            pset.setViewCount(Integer.parseInt(setElement.getAttribute("view_count")));
-	            pset.setCommentCount(Integer.parseInt(setElement.getAttribute("comment_count")));
-	            pset.setCountPhoto(Integer.parseInt(setElement.getAttribute("count_photo")));
-	            pset.setCountVideo(Integer.parseInt(setElement.getAttribute("count_video")));
-	            setList.add(pset);
-	            allContext.setPhotoSetList(setList);
-        	}else if(setElement.getTagName().equals("pool")){
-        		Pool pool = new Pool();
-        		pool.setTitle(setElement.getAttribute("title"));
-        		pool.setId(setElement.getAttribute("id"));
-        		pool.setUrl(setElement.getAttribute("url"));
-        		pool.setIconServer(setElement.getAttribute("iconserver"));
-        		pool.setIconFarm(setElement.getAttribute("iconfarm"));
-        		pool.setMemberCount(Integer.parseInt(setElement.getAttribute("members")));
-        		pool.setPoolCount(Integer.parseInt(setElement.getAttribute("pool_count")));
- 	            poolList.add(pool);
- 	            allContext.setPoolList(poolList);
-        	}
-    	}
-                
+        for (Element setElement : photosElement) {
+            if(setElement.getTagName().equals("set")){
+                PhotoSet pset = new PhotoSet();
+                pset.setTitle(setElement.getAttribute("title"));
+                pset.setSecret(setElement.getAttribute("secret"));
+                pset.setId(setElement.getAttribute("id"));
+                pset.setFarm(setElement.getAttribute("farm"));
+                pset.setPrimary(setElement.getAttribute("primary"));
+                pset.setServer(setElement.getAttribute("server"));
+                pset.setViewCount(Integer.parseInt(setElement.getAttribute("view_count")));
+                pset.setCommentCount(Integer.parseInt(setElement.getAttribute("comment_count")));
+                pset.setCountPhoto(Integer.parseInt(setElement.getAttribute("count_photo")));
+                pset.setCountVideo(Integer.parseInt(setElement.getAttribute("count_video")));
+                setList.add(pset);
+                allContext.setPhotoSetList(setList);
+            }else if(setElement.getTagName().equals("pool")){
+                Pool pool = new Pool();
+                pool.setTitle(setElement.getAttribute("title"));
+                pool.setId(setElement.getAttribute("id"));
+                pool.setUrl(setElement.getAttribute("url"));
+                pool.setIconServer(setElement.getAttribute("iconserver"));
+                pool.setIconFarm(setElement.getAttribute("iconfarm"));
+                pool.setMemberCount(Integer.parseInt(setElement.getAttribute("members")));
+                pool.setPoolCount(Integer.parseInt(setElement.getAttribute("pool_count")));
+                poolList.add(pool);
+                allContext.setPoolList(poolList);
+            }
+        }
+
         return allContext;
 
     }
 
     /**
      * Get photos from the user's contacts.
-     * 
+     *
      * This method requires authentication with 'read' permission.
-     * 
+     *
      * @param count
      *            The number of photos to return
      * @param justFriends
@@ -290,9 +291,9 @@ public class PhotosInterface {
 
     /**
      * Get public photos from the user's contacts.
-     * 
+     *
      * This method does not require authentication.
-     * 
+     *
      * @see com.flickr4java.flickr.photos.Extras
      * @param userId
      *            The user ID
@@ -365,9 +366,9 @@ public class PhotosInterface {
 
     /**
      * Get the context for the specified photo.
-     * 
+     *
      * This method does not require authentication.
-     * 
+     *
      * @param photoId
      *            The photo ID
      * @return The PhotoContext
@@ -410,9 +411,9 @@ public class PhotosInterface {
 
     /**
      * Gets a collection of photo counts for the given date ranges for the calling user.
-     * 
+     *
      * This method requires authentication with 'read' permission.
-     * 
+     *
      * @param dates
      *            An array of dates, denoting the periods to return counts for. They should be specified smallest first.
      * @param takenDates
@@ -464,11 +465,11 @@ public class PhotosInterface {
 
     /**
      * Get the Exif data for the photo.
-     * 
+     *
      * The calling user must have permission to view the photo.
-     * 
+     *
      * This method does not require authentication.
-     * 
+     *
      * @param photoId
      *            The photo ID
      * @param secret
@@ -508,9 +509,9 @@ public class PhotosInterface {
 
     /**
      * Returns the list of people who have favorited a given photo.
-     * 
+     *
      * This method does not require authentication.
-     * 
+     *
      * @param photoId
      * @param perPage
      * @param page
@@ -552,11 +553,11 @@ public class PhotosInterface {
 
     /**
      * Get all info for the specified photo.
-     * 
+     *
      * The calling user must have permission to view the photo.
-     * 
+     *
      * This method does not require authentication.
-     * 
+     *
      * @param photoId
      *            The photo Id
      * @param secret
@@ -583,10 +584,29 @@ public class PhotosInterface {
     }
 
     /**
+     * Returns json reponse as {@link StringBuilder} from flickr api<br/>
+     * Feasible when flickr4java is a flickr-api-proxy go get json
+     *
+     * @throws FlickrException
+     */
+    public StringBuilder getInfoAsJson(String photoId, String secret, boolean noJsonCallback) throws FlickrException {
+        Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("method", METHOD_GET_INFO);
+
+        parameters.put("photo_id", photoId);
+        if (secret != null) {
+            parameters.put("secret", secret);
+        }
+        JSONResponse jsonResponse = transport.getJson(transport.getPath(), parameters, apiKey, sharedSecret, noJsonCallback);
+
+        return jsonResponse.getBody();
+    }
+
+    /**
      * Return a collection of Photo objects not in part of any sets.
-     * 
+     *
      * This method requires authentication with 'read' permission.
-     * 
+     *
      * @param perPage
      *            The per page
      * @param page
@@ -634,9 +654,9 @@ public class PhotosInterface {
 
     /**
      * Get the permission information for the specified photo.
-     * 
+     *
      * This method requires authentication with 'read' permission.
-     * 
+     *
      * @param photoId
      *            The photo id
      * @return The Permissions object
@@ -665,9 +685,9 @@ public class PhotosInterface {
 
     /**
      * Get a collection of recent photos.
-     * 
+     *
      * This method does not require authentication.
-     * 
+     *
      * @see com.flickr4java.flickr.photos.Extras
      * @param extras
      *            Set of extra-fields
@@ -703,11 +723,11 @@ public class PhotosInterface {
 
     /**
      * Get the available sizes of a Photo.
-     * 
+     *
      * The calling user must have permission to view the photo.
-     * 
+     *
      * This method uses no authentication.
-     * 
+     *
      * @param photoId
      *            The photo ID
      * @return A collection of {@link Size}
@@ -717,13 +737,16 @@ public class PhotosInterface {
         return getSizes(photoId, false);
     }
 
+
+
+
     /**
      * Get the available sizes of a Photo.
-     * 
+     *
      * The boolean toggle allows to (api-)sign the call.
-     * 
+     *
      * This way the calling user can retrieve sizes for <b>his own</b> private photos.
-     * 
+     *
      * @param photoId
      *            The photo ID
      * @param sign
@@ -732,7 +755,7 @@ public class PhotosInterface {
      * @throws FlickrException
      */
     public Collection<Size> getSizes(String photoId, boolean sign) throws FlickrException {
-    	SizeList<Size> sizes = new  SizeList<Size>();
+        SizeList<Size> sizes = new  SizeList<Size>();
 
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("method", METHOD_GET_SIZES);
@@ -762,11 +785,20 @@ public class PhotosInterface {
         return sizes;
     }
 
+    public StringBuilder getSizesAsJson(String photoId, boolean noJsonCallback) throws FlickrException {
+        Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("method", METHOD_GET_SIZES);
+        parameters.put("photo_id", photoId);
+
+        JSONResponse response = transport.getJson(transport.getPath(), parameters, apiKey, sharedSecret, noJsonCallback);
+        return response.getBody();
+    }
+
     /**
      * Get the collection of untagged photos.
-     * 
+     *
      * This method requires authentication with 'read' permission.
-     * 
+     *
      * @param perPage
      * @param page
      * @return A Collection of Photos
@@ -794,9 +826,9 @@ public class PhotosInterface {
 
     /**
      * Returns a list of your geo-tagged photos.
-     * 
+     *
      * This method requires authentication with 'read' permission.
-     * 
+     *
      * @param minUploadDate
      *            Minimum upload date. Photos with an upload date greater than or equal to this value will be returned. Set to null to not specify a date.
      * @param maxUploadDate
@@ -815,7 +847,7 @@ public class PhotosInterface {
      *            <li>5 completely private photos</li>
      *            </ul>
      *            Set to 0 to not specify a privacy Filter.
-     * 
+     *
      * @see com.flickr4java.flickr.photos.Extras
      * @param sort
      *            The order in which to sort returned photos. Deafults to date-posted-desc. The possible values are: date-posted-asc, date-posted-desc,
@@ -831,7 +863,7 @@ public class PhotosInterface {
      * @throws FlickrException
      */
     public PhotoList<Photo> getWithGeoData(Date minUploadDate, Date maxUploadDate, Date minTakenDate, Date maxTakenDate, int privacyFilter, String sort,
-            Set<String> extras, int perPage, int page) throws FlickrException {
+                                           Set<String> extras, int perPage, int page) throws FlickrException {
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("method", METHOD_GET_WITH_GEO_DATA);
 
@@ -874,9 +906,9 @@ public class PhotosInterface {
 
     /**
      * Returns a list of your photos which haven't been geo-tagged.
-     * 
+     *
      * This method requires authentication with 'read' permission.
-     * 
+     *
      * @param minUploadDate
      *            Minimum upload date. Photos with an upload date greater than or equal to this value will be returned. Set to null to not specify a date.
      * @param maxUploadDate
@@ -895,7 +927,7 @@ public class PhotosInterface {
      *            <li>5 completely private photos</li>
      *            </ul>
      *            Set to 0 to not specify a privacy Filter.
-     * 
+     *
      * @see com.flickr4java.flickr.photos.Extras
      * @param sort
      *            The order in which to sort returned photos. Deafults to date-posted-desc. The possible values are: date-posted-asc, date-posted-desc,
@@ -911,7 +943,7 @@ public class PhotosInterface {
      * @throws FlickrException
      */
     public PhotoList<Photo> getWithoutGeoData(Date minUploadDate, Date maxUploadDate, Date minTakenDate, Date maxTakenDate, int privacyFilter, String sort,
-            Set<String> extras, int perPage, int page) throws FlickrException {
+                                              Set<String> extras, int perPage, int page) throws FlickrException {
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("method", METHOD_GET_WITHOUT_GEO_DATA);
 
@@ -955,9 +987,9 @@ public class PhotosInterface {
     /**
      * Return a list of your photos that have been recently created or which have been recently modified. Recently modified may mean that the photo's metadata
      * (title, description, tags) may have been changed or a comment has been added (or just modified somehow :-)
-     * 
+     *
      * This method requires authentication with 'read' permission.
-     * 
+     *
      * @see com.flickr4java.flickr.photos.Extras
      * @param minDate
      *            Date indicating the date from which modifications should be compared. Must be given.
@@ -998,9 +1030,9 @@ public class PhotosInterface {
 
     /**
      * Remove a tag from a photo.
-     * 
+     *
      * This method requires authentication with 'write' permission.
-     * 
+     *
      * @param tagId
      *            The tag ID
      * @throws FlickrException
@@ -1019,7 +1051,7 @@ public class PhotosInterface {
 
     /**
      * Search for photos which match the given search parameters.
-     * 
+     *
      * @param params
      *            The search parameters
      * @param perPage
@@ -1064,7 +1096,7 @@ public class PhotosInterface {
 
     /**
      * Search for interesting photos using the Flickr Interestingness algorithm.
-     * 
+     *
      * @param params
      *            Any search parameters
      * @param perPage
@@ -1123,9 +1155,9 @@ public class PhotosInterface {
 
     /**
      * Set the content type of a photo.
-     * 
+     *
      * This method requires authentication with 'write' permission.
-     * 
+     *
      * @see com.flickr4java.flickr.Flickr#CONTENTTYPE_PHOTO
      * @see com.flickr4java.flickr.Flickr#CONTENTTYPE_SCREENSHOT
      * @see com.flickr4java.flickr.Flickr#CONTENTTYPE_OTHER
@@ -1150,9 +1182,9 @@ public class PhotosInterface {
 
     /**
      * Set the dates for the specified photo.
-     * 
+     *
      * This method requires authentication with 'write' permission.
-     * 
+     *
      * @param photoId
      *            The photo ID
      * @param datePosted
@@ -1189,9 +1221,9 @@ public class PhotosInterface {
 
     /**
      * Set the meta data for the photo.
-     * 
+     *
      * This method requires authentication with 'write' permission.
-     * 
+     *
      * @param photoId
      *            The photo ID
      * @param title
@@ -1216,9 +1248,9 @@ public class PhotosInterface {
 
     /**
      * Set the permissions for the photo.
-     * 
+     *
      * This method requires authentication with 'write' permission.
-     * 
+     *
      * @param photoId
      *            The photo ID
      * @param permissions
@@ -1245,9 +1277,9 @@ public class PhotosInterface {
     /**
      * Set the safety level (adultness) of a photo.
      * <p>
-     * 
+     *
      * This method requires authentication with 'write' permission.
-     * 
+     *
      * @param photoId
      *            The photo ID
      * @param safetyLevel
@@ -1281,9 +1313,9 @@ public class PhotosInterface {
 
     /**
      * Set the tags for a photo.
-     * 
+     *
      * This method requires authentication with 'write' permission.
-     * 
+     *
      * @param photoId
      *            The photo ID
      * @param tags
@@ -1305,7 +1337,7 @@ public class PhotosInterface {
 
     /**
      * Get the photo for the specified ID. Currently maps to the getInfo() method.
-     * 
+     *
      * @param id
      *            The ID
      * @return The Photo
@@ -1316,7 +1348,7 @@ public class PhotosInterface {
 
     /**
      * Get the photo for the specified ID with the given secret. Currently maps to the getInfo() method.
-     * 
+     *
      * @param id
      *            The ID
      * @param secret
@@ -1331,9 +1363,9 @@ public class PhotosInterface {
      * Request an image from the Flickr-servers.<br>
      * Callers must close the stream upon completion.
      * <p>
-     * 
+     *
      * At {@link Size} you can find constants for the available sizes.
-     * 
+     *
      * @param photo
      *            A photo-object
      * @param size
@@ -1369,18 +1401,18 @@ public class PhotosInterface {
             } else if (size == Size.MEDIUM_800) {
                 urlStr = photo.getMedium800Url();
             } else if (size == Size.VIDEO_ORIGINAL) {
-            	urlStr = photo.getVideoOriginalUrl();
+                urlStr = photo.getVideoOriginalUrl();
             } else if (size == Size.VIDEO_PLAYER) {
-            	urlStr = photo.getVideoPlayerUrl();
+                urlStr = photo.getVideoPlayerUrl();
             } else if (size == Size.SITE_MP4) {
-            	urlStr = photo.getSiteMP4Url();
-            } 
-    		else if(size == Size.MOBILE_MP4) {
-    			urlStr = photo.getMobileMp4Url();
-    		}
-    		else if(size == Size.HD_MP4) {
-    			urlStr = photo.getHdMp4Url();
-    		} else {
+                urlStr = photo.getSiteMP4Url();
+            }
+            else if(size == Size.MOBILE_MP4) {
+                urlStr = photo.getMobileMp4Url();
+            }
+            else if(size == Size.HD_MP4) {
+                urlStr = photo.getHdMp4Url();
+            } else {
                 throw new FlickrException("0", "Unknown Photo-size");
             }
             URL url = new URL(urlStr);
@@ -1400,9 +1432,9 @@ public class PhotosInterface {
     /**
      * Request an image from the Flickr-servers.
      * <p>
-     * 
+     *
      * At {@link Size} you can find constants for the available sizes.
-     * 
+     *
      * @param photo
      *            A photo-object
      * @param size
@@ -1420,7 +1452,7 @@ public class PhotosInterface {
 
     /**
      * Download of an image by URL.
-     * 
+     *
      * @param urlStr
      *            The URL of a Photo
      * @return BufferedImage The The Image

--- a/Flickr4Java/src/main/java/com/flickr4java/flickr/util/StringUtilities.java
+++ b/Flickr4Java/src/main/java/com/flickr4java/flickr/util/StringUtilities.java
@@ -10,7 +10,10 @@ import java.util.regex.Pattern;
 
 /**
  * String utility methods.
- * 
+ *
+ *
+ * // TODO: what about adding org.apache.commons.lang3 ?
+ *
  * @author Anthony Eden
  * @version $Id: StringUtilities.java,v 1.5 2009/07/23 20:41:03 x-mago Exp $
  */
@@ -21,9 +24,18 @@ public class StringUtilities {
 
     }
 
+    public static boolean isNotBlank(String string){
+        return string != null && string.length()>0;
+    }
+
+    public static boolean isBlank(String string){
+        return string == null && string.length()==0;
+    }
+
+
     /**
      * Join the array of Strings using the specified delimiter.
-     * 
+     *
      * @param s
      *            The String array
      * @param delimiter
@@ -40,7 +52,7 @@ public class StringUtilities {
 
     /**
      * Join the Collection of Strings using the specified delimter and optionally quoting each
-     * 
+     *
      * @param s
      *            The String collection
      * @param delimiter
@@ -67,7 +79,7 @@ public class StringUtilities {
 
     /**
      * Join the Collection of Strings using the specified delimiter.
-     * 
+     *
      * @param s
      *            The String collection
      * @param delimiter


### PR DESCRIPTION
Enable to fetch json-response from flickr (no unmarshalling).

Would be feasible for my app. I've done a 1st attempt in a way which will not break existing API, however, it is not very elegant.

The main change would be Transport#getJson.
Then i've added PhotosInterface#getInfoAsJson and getSizesAsJson (as alternative to getInfo) ... and i would need more.
(For this reason i've also introduced JSONResponse and JSONResponseImpl.)

I could add all the methods i need, but to do it for at least all get#methods on PhotosInterface and PhotosetsInterface it would be a lot of boilerplate work duplicating all the methods ... not a good approach.
So would be interested in how to enable json in a more elegant way (and to avoid to break API  ... changing the signature of these getter methods).
