### PR TITLE
missing fields in returned object of PeopleInterface#getGroups(String userId)

### DIFF
--- a/Flickr4Java/src/main/java/com/flickr4java/flickr/people/PeopleInterface.java
+++ b/Flickr4Java/src/main/java/com/flickr4java/flickr/people/PeopleInterface.java
@@ -537,6 +537,8 @@ public class PeopleInterface {
             group.setAdmin("1".equals(groupElement.getAttribute("admin")));
             group.setEighteenPlus("1".equals(groupElement.getAttribute("eighteenplus")));
             group.setInvitationOnly("1".equals(groupElement.getAttribute("invitation_only")));
+            group.setMembers(groupElement.getAttribute("members"));
+            group.setPhotoCount(groupElement.getAttribute("pool_count"));
             groupList.add(group);
         }
         return groupList;


### PR DESCRIPTION
PeopleInterfase#getGroups(String userId) doesn't set the fields members and poolCount of the Group objects in the returned GroupList<Group>
