### PR TITLE
Updated radius value in Search Parameters to take in type double.

### DIFF
--- a/Flickr4Java/src/main/java/com/flickr4java/flickr/photos/SearchParameters.java
+++ b/Flickr4Java/src/main/java/com/flickr4java/flickr/photos/SearchParameters.java
@@ -67,7 +67,7 @@ public class SearchParameters {
 
     private String longitude;
 
-    private int radius = -1;
+    private double radius = -1;
 
     private String radiusUnits;
 
@@ -660,7 +660,7 @@ public class SearchParameters {
         latitude = lat;
     }
 
-    public void setRadius(int r) {
+    public void setRadius(double r) {
         radius = r;
     }
 


### PR DESCRIPTION
Flickr API allows the radius to be in decimals as well, I've tried this on the Flickr API Explore and it's able to give me search requests. Changed the `setReturn(double r)` function and updated the type of radius to `double`. Cheers!