### PR TITLE
set stats on Photo objects if requested via extras in SearchParameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.flickr4java</groupId>
     <artifactId>flickr4java</artifactId>
-    <version>3.0.3-SNAPSHOT</version>
+    <version>3.0.4-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>flickr4java</name>
     <description>Java API For Flickr. Fork of FlickrJ.</description>

--- a/src/main/java/com/flickr4java/flickr/photos/PhotoUtils.java
+++ b/src/main/java/com/flickr4java/flickr/photos/PhotoUtils.java
@@ -2,6 +2,7 @@ package com.flickr4java.flickr.photos;
 
 import com.flickr4java.flickr.people.User;
 import com.flickr4java.flickr.places.Place;
+import com.flickr4java.flickr.stats.Stats;
 import com.flickr4java.flickr.tags.Tag;
 import com.flickr4java.flickr.util.XMLUtilities;
 
@@ -486,6 +487,17 @@ public final class PhotoUtils {
             Element element = (Element) photoElement.getElementsByTagName("country").item(0);
             place = new Place(element.getAttribute("place_id"), element.getTextContent(), element.getAttribute("woeid"));
             photo.setCountry(place);
+        } catch (IndexOutOfBoundsException e) {
+        } catch (NullPointerException e) {
+        }
+        
+        //set stats from extras (count_faves,count_comments,count_views)
+        try {
+            Stats stats = new Stats();;
+            stats.setFavorites(photoElement.getAttribute("count_faves"));
+            stats.setComments(photoElement.getAttribute("count_comments"));
+            stats.setViews(photoElement.getAttribute("count_views"));
+            photo.setStats(stats);
         } catch (IndexOutOfBoundsException e) {
         } catch (NullPointerException e) {
         }

--- a/src/main/java/com/flickr4java/flickr/photos/SearchParameters.java
+++ b/src/main/java/com/flickr4java/flickr/photos/SearchParameters.java
@@ -302,7 +302,7 @@ public class SearchParameters {
 
     /**
      * List of extra information to fetch for each returned record. Currently supported fields are: license, date_upload, date_taken, owner_name, icon_server,
-     * original_format, last_update, geo, tags, machine_tags, o_dims, views, media, path_alias, url_sq, url_t, url_s, url_m, url_l, url_o
+     * original_format, last_update, geo, tags, machine_tags, o_dims, views, media, path_alias, url_sq, url_t, url_s, url_m, url_l, url_o,count_faves,count_comments,count_views
      * 
      * @param extras
      *            A set of extra-attributes


### PR DESCRIPTION
Not a *totally* documented feature, but better than just dropping the SearchParameters extras on the floor.

https://www.flickr.com/groups/51035612836@N01/discuss/72157636063789543/

If you don't pass the extras parameters the fix will catch the NPE and no-op, as before.