### PR TITLE
Update dependencies, fix javadoc errors, OAuth refactor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,9 @@
 
     <properties>
         <javaVersion>1.8</javaVersion>
-        <junitVersion>4.11</junitVersion>
-        <slf4j.version>1.7.25</slf4j.version>
-        <scribe.version>6.2.0</scribe.version>
+        <junitVersion>4.13</junitVersion>
+        <slf4j.version>1.7.30</slf4j.version>
+        <scribe.version>6.9.0</scribe.version>
     </properties>
 
     <dependencies>
@@ -71,7 +71,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.1</version>
+                    <version>2.5.3</version>
                     <configuration>
                         <mavenExecutorId>forked-path</mavenExecutorId>
                         <useReleaseProfile>false</useReleaseProfile>
@@ -85,7 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>${javaVersion}</source>
                     <target>${javaVersion}</target>
@@ -94,7 +94,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>2.22.2</version>
                 <configuration>
                     <environmentVariables>
                         <SETUP_PROPERTIES_PATH>${setupPropertiesPath}</SETUP_PROPERTIES_PATH>
@@ -104,7 +104,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -118,7 +118,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -202,7 +202,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.1</version>
+                        <version>1.6</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -222,7 +222,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>2.20.1</version>
+                <version>2.22.2</version>
             </plugin>
         </plugins>
     </reporting>

--- a/src/main/java/com/flickr4java/flickr/Flickr.java
+++ b/src/main/java/com/flickr4java/flickr/Flickr.java
@@ -49,7 +49,7 @@ import java.util.Set;
  * <p>
  * 
  * The user who authenticates himself, can manage this permissions at <a href="http://www.flickr.com/services/auth/list.gne">his list of Third-party
- * applications</a> (You -> Your account -> Extending Flickr -> Account Links -> edit).
+ * applications</a> (You / Your account / Extending Flickr / Account Links / edit).
  * 
  * @author Anthony Eden
  * @version $Id: Flickr.java,v 1.45 2009/06/23 21:51:25 x-mago Exp $

--- a/src/main/java/com/flickr4java/flickr/Transport.java
+++ b/src/main/java/com/flickr4java/flickr/Transport.java
@@ -132,7 +132,7 @@ public abstract class Transport {
      * @param parameters
      *            The parameters
      * @return The Response
-     * @throws FlickrException
+     * @throws FlickrRuntimeException
      */
     public abstract Response getNonOAuth(String path, Map<String, String> parameters) throws FlickrRuntimeException;
 

--- a/src/main/java/com/flickr4java/flickr/contacts/Contact.java
+++ b/src/main/java/com/flickr4java/flickr/contacts/Contact.java
@@ -159,7 +159,7 @@ public class Contact implements BuddyIconable {
 
     /**
      * Get the contact's path alias, which may appear instead of nsid in urls published by Flickr. For example feeds have urls of the form
-     * .../photos/${NSID_OR_PATHALIAS}/${PHOTO_ID} & .../people/${NSID_OR_PATHALIAS}. This allows clients to look up a {@link Contact} given such a url. (Note
+     * .../photos/${NSID_OR_PATHALIAS}/${PHOTO_ID} and .../people/${NSID_OR_PATHALIAS}. This allows clients to look up a {@link Contact} given such a url. (Note
      * that <code>&lt;author&gt;</code> elements in feeds have a <code>&lt;flickr:nsid&gt;</code> child which could be used instead of the lookup this method
      * enables.)
      * 

--- a/src/main/java/com/flickr4java/flickr/contacts/ContactsInterface.java
+++ b/src/main/java/com/flickr4java/flickr/contacts/ContactsInterface.java
@@ -94,7 +94,7 @@ public class ContactsInterface {
      *            Limits the resultset to contacts that have uploaded photos since this date. The date should be in the form of a Unix timestamp. The default,
      *            and maximum, offset is (1) hour. (Optional, can be null)
      * @param filter
-     *            Limit the result set to all contacts or only those who are friends or family.<br/>
+     *            Limit the result set to all contacts or only those who are friends or family.<br>
      *            Valid options are: <b>ff</b> -&gt; friends and family, <b>all</b> -&gt; all your contacts. (Optional, can be null)
      * 
      * @return List of Contacts

--- a/src/main/java/com/flickr4java/flickr/favorites/FavoritesInterface.java
+++ b/src/main/java/com/flickr4java/flickr/favorites/FavoritesInterface.java
@@ -75,9 +75,9 @@ public class FavoritesInterface {
      * @param userId
      *            The optional user ID. Null value will be ignored.
      * @param perPage
-     *            The optional per page value. Values <= 0 will be ignored.
+     *            The optional per page value. Values {@code <= 0} will be ignored.
      * @param page
-     *            The page to view. Values <= 0 will be ignored.
+     *            The page to view. Values {@code <= 0} will be ignored.
      * @param extras
      *            a Set Strings representing extra parameters to send
      * @return The Collection of Photo objects
@@ -128,9 +128,9 @@ public class FavoritesInterface {
      * @param userId
      *            The user ID
      * @param perPage
-     *            The optional per page value. Values <= 0 will be ignored.
+     *            The optional per page value. Values {@code <= 0} will be ignored.
      * @param page
-     *            The optional page to view. Values <= 0 will be ignored
+     *            The optional page to view. Values {@code <= 0} will be ignored
      * @param extras
      *            A Set of extra parameters to send
      * @return A Collection of Photo objects

--- a/src/main/java/com/flickr4java/flickr/galleries/GalleriesInterface.java
+++ b/src/main/java/com/flickr4java/flickr/galleries/GalleriesInterface.java
@@ -77,7 +77,7 @@ public class GalleriesInterface {
      * @return gallery
      * @throws FlickrException
      * 
-     * @see <a hrerf="http://www.flickr.com/services/api/flickr.galleries.getList.html">flickr.galleries.getList</a>
+     * @see <a href="https://www.flickr.com/services/api/flickr.galleries.getList.html">flickr.galleries.getList</a>
      */
     public List<Gallery> getList(String userId, int perPage, int page) throws FlickrException {
         Map<String, Object> parameters = new HashMap<String, Object>();

--- a/src/main/java/com/flickr4java/flickr/groups/discuss/GroupDiscussInterface.java
+++ b/src/main/java/com/flickr4java/flickr/groups/discuss/GroupDiscussInterface.java
@@ -42,7 +42,7 @@ public class GroupDiscussInterface {
      * Get a list of topics from a group.
      * 
      * @param groupId
-     *            Unique identifier of a group returns a list of topics for a given group {@link Group}.
+     *            Unique identifier of a group returns a list of topics for a given group {@link com.flickr4java.flickr.groups.Group}.
      * @param perPage
      *            Number of records per page.
      * @param page

--- a/src/main/java/com/flickr4java/flickr/machinetags/MachinetagsInterface.java
+++ b/src/main/java/com/flickr4java/flickr/machinetags/MachinetagsInterface.java
@@ -43,18 +43,18 @@ import java.util.Map;
  * is the excellent "Flickr Upcoming Event" greasemonkey script:
  * <p>
  * 
- * {@link <a href="http://userscripts.org/scripts/show/5464">http://userscripts.org/scripts/show/5464</a>}
+ * <a href="https://web.archive.org/web/20131103192452/http://userscripts.org/scripts/show/5464">Flickr Upcoming Event</a>
  * <p>
  * 
  * Dan Catt wrote a very good piece about machine tags - he called them "triple tags" - last year:
  * <p>
  * 
- * {@link <a href="http://geobloggers.com/archives/2006/01/11/advanced-tagging-and-tripletags/">http://geobloggers.com/archives/2006/01/11/advanced-tagging-and-tripletags/</a>}
+ * <a href="https://web.archive.org/web/20080617093009/http://geobloggers.com:80/archives/2006/01/11/advanced-tagging-and-tripletags/">Advanced Tagging and TripleTags</a>
  * <p>
  * 
  * Update : Dan's gone and written another excellent piece about all of this stuff now that we've launched machine tags:
  * 
- * {@link <a href="http://geobloggers.com/archives/2007/01/24/offtopic-ish-flickr-ramps-up-triple-tag-support/">http://geobloggers.com/archives/2007/01/24/offtopic-ish-flickr-ramps-up-triple-tag-support/</a>}
+ * <a href="https://web.archive.org/web/20080621114435/http://geobloggers.com/archives/2007/01/24/offtopic-ish-flickr-ramps-up-triple-tag-support/">Flickr Ramps up Triple Tag (Machine Tags) Support</a>
  * </li>
  * </ul>
  * <p>
@@ -130,37 +130,37 @@ import java.util.Map;
  * <li>Find photos using the 'dc' namespace:
  * <p>
  * 
- * {"machine_tags" => "dc:"}</li>
+ * {"machine_tags" =&gt; "dc:"}</li>
  * 
  * <li>Find photos with a title in the 'dc' namespace:
  * <p>
  * 
- * {"machine_tags" => "dc:title="}</li>
+ * {"machine_tags" =&gt; "dc:title="}</li>
  * 
  * <li>Find photos titled "mr. camera" in the 'dc' namespace:
  * <p>
  * 
- * {"machine_tags" => "dc:title=\"mr. camera\"}</li>
+ * {"machine_tags" =&gt; "dc:title=\"mr. camera\"}</li>
  * 
  * <li>Find photos whose value is "mr. camera":
  * <p>
  * 
- * {"machine_tags" => "*:*=\"mr. camera\""}</li>
+ * {"machine_tags" =&gt; "*:*=\"mr. camera\""}</li>
  * 
  * <li>Find photos that have a title, in any namespace:
  * <p>
  * 
- * {"machine_tags" => "*:title="}</li>
+ * {"machine_tags" =&gt; "*:title="}</li>
  * 
  * <li>Find photos that have a title, in any namespace, whose value is "mr. camera":
  * <p>
  * 
- * {"machine_tags" => "*:title=\"mr. camera\""}</li>
+ * {"machine_tags" =&gt; "*:title=\"mr. camera\""}</li>
  * 
  * <li>Find photos, in the 'dc' namespace whose value is "mr. camera":
  * <p>
  * 
- * {"machine_tags" => "dc:*=\"mr. camera\""}</li>
+ * {"machine_tags" =&gt; "dc:*=\"mr. camera\""}</li>
  * </ul>
  * 
  * <h3>Is there a limit to the number of machine tags I can query?</h3>
@@ -215,7 +215,7 @@ import java.util.Map;
  * 
  * See also:
  * 
- * {@link <a href="http://weblog.scifihifi.com/2005/08/05/meta-tags-the-poor-mans-rdf">http://weblog.scifihifi.com/2005/08/05/meta-tags-the-poor-mans-rdf</a>}
+ * <a href="https://web.archive.org/web/20110716015005/http://weblog.scifihifi.com/2005/08/05/meta-tags-the-poor-mans-rdf/">Meta Tags: The Poor Man’s RDF?</a>
  * 
  * <h3>Huh, what is RDF?</h3>
  * 

--- a/src/main/java/com/flickr4java/flickr/people/User.java
+++ b/src/main/java/com/flickr4java/flickr/people/User.java
@@ -516,7 +516,7 @@ public class User implements Serializable, BuddyIconable {
 
     /**
      * Get the user's path alias, which may appear instead of nsid in urls published by Flickr. For example feeds have urls of the form
-     * .../photos/${NSID_OR_PATHALIAS}/${PHOTO_ID} & .../people/${NSID_OR_PATHALIAS}. This allows clients to look up a {@link User} given such a url. (Note that
+     * .../photos/${NSID_OR_PATHALIAS}/${PHOTO_ID} and .../people/${NSID_OR_PATHALIAS}. This allows clients to look up a {@link User} given such a url. (Note that
      * <code>&lt;author&gt;</code> elements in feeds have a <code>&lt;flickr:nsid&gt;</code> child which could be used instead of the lookup this method
      * enables.)
      * 

--- a/src/main/java/com/flickr4java/flickr/photos/PhotosInterface.java
+++ b/src/main/java/com/flickr4java/flickr/photos/PhotosInterface.java
@@ -809,7 +809,7 @@ public class PhotosInterface {
      *            <li>1 public photos</li>
      *            <li>2 private photos visible to friends</li>
      *            <li>3 private photos visible to family</li>
-     *            <li>4 private photos visible to friends & family</li>
+     *            <li>4 private photos visible to friends and family</li>
      *            <li>5 completely private photos</li>
      *            </ul>
      *            Set to 0 to not specify a privacy Filter.
@@ -889,7 +889,7 @@ public class PhotosInterface {
      *            <li>1 public photos</li>
      *            <li>2 private photos visible to friends</li>
      *            <li>3 private photos visible to family</li>
-     *            <li>4 private photos visible to friends & family</li>
+     *            <li>4 private photos visible to friends and family</li>
      *            <li>5 completely private photos</li>
      *            </ul>
      *            Set to 0 to not specify a privacy Filter.

--- a/src/main/java/com/flickr4java/flickr/photos/SearchParameters.java
+++ b/src/main/java/com/flickr4java/flickr/photos/SearchParameters.java
@@ -155,7 +155,7 @@ public class SearchParameters {
      *            <li>1 public photos
      *            <li>2 private photos visible to friends
      *            <li>3 private photos visible to family
-     *            <li>4 private photos visible to friends &amp; family
+     *            <li>4 private photos visible to friends and family
      *            <li>5 completely private photos
      *            </ul>
      */
@@ -184,7 +184,7 @@ public class SearchParameters {
      * "parameterless searches" for queries without a geo component.
      * <p>
      * 
-     * A tag, for instance, is considered a limiting agent as are user defined min_date_taken and min_date_upload parameters &emdash; If no limiting factor is
+     * A tag, for instance, is considered a limiting agent as are user defined min_date_taken and min_date_upload parameters &mdash; If no limiting factor is
      * passed flickr will return only photos added in the last 12 hours (though flickr may extend the limit in the future).
      * 
      * @param hasGeo
@@ -394,7 +394,6 @@ public class SearchParameters {
      * @return A placeId
      * @see com.flickr4java.flickr.places.PlacesInterface#resolvePlaceId(String)
      */
-    @SuppressWarnings("javadoc")
     public String getPlaceId() {
         return placeId;
     }
@@ -406,7 +405,7 @@ public class SearchParameters {
      * "parameterless searches" for queries without a geo component.
      * <p>
      * 
-     * A tag, for instance, is considered a limiting agent as are user defined min_date_taken and min_date_upload parameters &emdash; If no limiting factor is
+     * A tag, for instance, is considered a limiting agent as are user defined min_date_taken and min_date_upload parameters &mdash; If no limiting factor is
      * passed we return only photos added in the last 12 hours (though we may extend the limit in the future).
      * 
      * @param placeId
@@ -414,7 +413,6 @@ public class SearchParameters {
      * @see com.flickr4java.flickr.places.Place#getPlaceId()
      * @see com.flickr4java.flickr.places.Location#getPlaceId()
      */
-    @SuppressWarnings("javadoc")
     public void setPlaceId(String placeId) {
         this.placeId = placeId;
     }
@@ -427,15 +425,15 @@ public class SearchParameters {
      * A Where on Earth identifier to use to filter photo clusters.<br>
      * For example all the photos clustered by locality in the United States (WOE ID 23424977).<br>
      * (not used if bbox argument is present).
-     * <p/>
+     * <p>
      * 
      * Geo queries require some sort of limiting agent in order to prevent the database from crying. This is basically like the check against
      * "parameterless searches" for queries without a geo component.
-     * <p/>
+     * <p>
      * 
      * A tag, for instance, is considered a limiting agent as are user defined min_date_taken and min_date_upload parameters. If no limiting factor is passed we
      * return only photos added in the last 12 hours (though flickr may extend the limit in the future).
-     * <p/>
+     * <p>
      * 
      * @param woeId
      * @see com.flickr4java.flickr.places.Place#getWoeId()
@@ -468,7 +466,7 @@ public class SearchParameters {
 
     /**
      * Search your contacts. Valid arguments are either 'all' or 'ff' for just friends and family.
-     * <p/>
+     * <p>
      * 
      * It requires that the "user_id" field also be set and allows you to limit queries to only photos belonging to that user's photos. As in : All my contacts
      * photos tagged "aaron". (Experimental)

--- a/src/main/java/com/flickr4java/flickr/photosets/PhotosetsInterface.java
+++ b/src/main/java/com/flickr4java/flickr/photosets/PhotosetsInterface.java
@@ -77,7 +77,7 @@ public class PhotosetsInterface {
 
     /**
      * Add a photo to the end of the photoset.
-     * <p/>
+     * <p>
      * Note: requires authentication with the new authentication API with 'write' permission.
      * 
      * @param photosetId

--- a/src/main/java/com/flickr4java/flickr/places/PlacesInterface.java
+++ b/src/main/java/com/flickr4java/flickr/places/PlacesInterface.java
@@ -25,7 +25,7 @@ import java.util.Map;
  * <p>
  * 
  * <PRE>
- * From: kellan <kellan@yahoo-inc.com>
+ * From: kellan - kellan@yahoo-inc.com
  * Date: Fri, 11 Jan 2008 15:57:59 -0800
  * Subject: [yws-flickr] Flickr and "Place IDs"
  * 

--- a/src/main/java/com/flickr4java/flickr/tags/TagsInterface.java
+++ b/src/main/java/com/flickr4java/flickr/tags/TagsInterface.java
@@ -70,7 +70,6 @@ public class TagsInterface {
 
     /**
      * Search for tag-clusters.
-     * <p/>
      * 
      * <p>
      * This method does not require authentication.

--- a/src/main/java/com/flickr4java/flickr/util/OAuthUtilities.java
+++ b/src/main/java/com/flickr4java/flickr/util/OAuthUtilities.java
@@ -1,0 +1,114 @@
+package com.flickr4java.flickr.util;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.flickr4java.flickr.Flickr;
+import com.flickr4java.flickr.RequestContext;
+import com.flickr4java.flickr.auth.Auth;
+import com.github.scribejava.apis.FlickrApi;
+import com.github.scribejava.core.builder.ServiceBuilder;
+import com.github.scribejava.core.httpclient.jdk.JDKHttpClientConfig;
+import com.github.scribejava.core.model.OAuth1AccessToken;
+import com.github.scribejava.core.model.OAuthRequest;
+import com.github.scribejava.core.model.Verb;
+import com.github.scribejava.core.oauth.OAuth10aService;
+
+/**
+ * OAuth utilities.
+ * 
+ * @author Vincent Privat
+ */
+public final class OAuthUtilities {
+
+    private static final Logger logger = LoggerFactory.getLogger(OAuthUtilities.class);
+
+    private OAuthUtilities() {
+
+    }
+
+    /**
+     * Creates a new OAuth 1.0.a service.
+     * 
+     * @param apiKey OAuth API key
+     * @param sharedSecret OAuth API secret
+     * @param connectTimeoutMs connect timeout in milliseconds
+     * @param readTimeoutMs read timeout in milliseconds
+     *
+     * @return OAuth 1.0.a service
+     */
+    public static OAuth10aService createOAuthService(String apiKey, String sharedSecret, Integer connectTimeoutMs, Integer readTimeoutMs) {
+        JDKHttpClientConfig config = JDKHttpClientConfig.defaultConfig();
+        if (connectTimeoutMs != null) {
+            config.setConnectTimeout(connectTimeoutMs);
+        }
+        if (readTimeoutMs != null) {
+            config.setReadTimeout(readTimeoutMs);
+        }
+        ServiceBuilder serviceBuilder = new ServiceBuilder(apiKey).apiSecret(sharedSecret).httpClientConfig(config);
+
+        if (Flickr.debugRequest) {
+            serviceBuilder = serviceBuilder.debug();
+        }
+
+        return serviceBuilder.build(FlickrApi.instance());
+    }
+
+    /**
+     * Signs the given OAuth request using the given OAuth service. 
+     *
+     * @param service OAuth 1.0.a service
+     * @param request OAuth request
+     * @param proxyCredentials optional proxy credentials, can be null
+     */
+    public static void signRequest(OAuth10aService service, OAuthRequest request, String proxyCredentials) {
+        Auth auth = RequestContext.getRequestContext().getAuth();
+        if (auth != null) {
+            service.signRequest(new OAuth1AccessToken(auth.getToken(), auth.getTokenSecret()), request);
+        }
+
+        if (proxyCredentials != null) {
+            request.addHeader("Proxy-Authorization", "Basic " + proxyCredentials);
+        }
+
+        if (Flickr.debugRequest) {
+            logger.debug("POST: {}", request.getCompleteUrl());
+        }
+    }
+
+    /**
+     * Builds a normal POST request.
+     *
+     * @param parameters body parameters
+     * @param url URL
+     * @return OAuth request
+     */
+    public static OAuthRequest buildNormalPostRequest(Map<String, ?> parameters, String url) {
+        OAuthRequest request = new OAuthRequest(Verb.POST, url);
+        parameters.entrySet().forEach(e -> request.addBodyParameter(e.getKey(), String.valueOf(e.getValue())));
+        return request;
+    }
+
+    /**
+     * Builds a multipart POST request.
+     *
+     * @param parameters QueryString parameters
+     * @param url URL
+     * @return OAuth request
+     */
+    public static OAuthRequest buildMultipartRequest(Map<String, String> parameters, String url) {
+        OAuthRequest request = new OAuthRequest(Verb.POST, url);
+        String multipartBoundary = getMultipartBoundary();
+        request.initMultipartPayload(multipartBoundary);
+        request.addHeader("Content-Type", "multipart/form-data; boundary=" + multipartBoundary);
+        parameters.entrySet().forEach(e -> request.addQuerystringParameter(e.getKey(), e.getValue()));
+        return request;
+    }
+
+    private static String getMultipartBoundary() {
+        return "---------------------------" + UUID.randomUUID();
+    }
+}

--- a/src/test/java/com/flickr4java/flickr/test/CamerasInterfaceTest.java
+++ b/src/test/java/com/flickr4java/flickr/test/CamerasInterfaceTest.java
@@ -1,7 +1,7 @@
 package com.flickr4java.flickr.test;
 
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import com.flickr4java.flickr.Flickr;
 import com.flickr4java.flickr.FlickrException;

--- a/src/test/java/com/flickr4java/flickr/test/CommentsInterfaceTest.java
+++ b/src/test/java/com/flickr4java/flickr/test/CommentsInterfaceTest.java
@@ -1,6 +1,5 @@
 package com.flickr4java.flickr.test;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/com/flickr4java/flickr/test/FavoritesInterfaceTest.java
+++ b/src/test/java/com/flickr4java/flickr/test/FavoritesInterfaceTest.java
@@ -16,7 +16,6 @@ import com.flickr4java.flickr.photos.PhotoContext;
 import org.junit.Test;
 
 import java.util.Collection;
-import java.util.Iterator;
 
 /**
  * @author Anthony Eden

--- a/src/test/java/com/flickr4java/flickr/test/InterestingnessInterfaceTest.java
+++ b/src/test/java/com/flickr4java/flickr/test/InterestingnessInterfaceTest.java
@@ -3,7 +3,6 @@ package com.flickr4java.flickr.test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import com.flickr4java.flickr.FlickrException;
 import com.flickr4java.flickr.interestingness.InterestingnessInterface;

--- a/src/test/java/com/flickr4java/flickr/test/OAuthUtilitiesTest.java
+++ b/src/test/java/com/flickr4java/flickr/test/OAuthUtilitiesTest.java
@@ -1,0 +1,73 @@
+package com.flickr4java.flickr.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.flickr4java.flickr.util.OAuthUtilities;
+import com.github.scribejava.apis.FlickrApi;
+import com.github.scribejava.core.builder.ServiceBuilder;
+import com.github.scribejava.core.model.OAuthRequest;
+import com.github.scribejava.core.model.Parameter;
+import com.github.scribejava.core.model.Verb;
+import com.github.scribejava.core.oauth.OAuth10aService;
+
+public class OAuthUtilitiesTest extends Flickr4JavaTest {
+
+    @Test
+    public void testCreateOAuthService() {
+        OAuth10aService service = OAuthUtilities.createOAuthService("foo", "bar", null, null);
+        assertEquals("foo", service.getApiKey());
+        assertEquals("bar", service.getApiSecret());
+
+        service = OAuthUtilities.createOAuthService("foo", "bar", 1, 2);
+        assertEquals("foo", service.getApiKey());
+        assertEquals("bar", service.getApiSecret());
+    }
+
+    @Test
+    public void testSignRequest() {
+        // No proxy credentials
+        OAuth10aService service = new ServiceBuilder("foo").build(FlickrApi.instance());
+        OAuthRequest request = new OAuthRequest(Verb.GET, "http://foobar");
+        assertTrue(request.getOauthParameters().isEmpty());
+        OAuthUtilities.signRequest(service, request, null);
+        assertNull(request.getHeaders().get("Proxy-Authorization"));
+
+        // proxy credentials
+        service = new ServiceBuilder("foo").apiSecret("bar").build(FlickrApi.instance());
+        request = new OAuthRequest(Verb.POST, "http://foobar");
+        assertTrue(request.getOauthParameters().isEmpty());
+        OAuthUtilities.signRequest(service, request, "creds");
+        assertEquals("Basic creds", request.getHeaders().get("Proxy-Authorization"));
+    }
+
+    @Test
+    public void testBuildNormalPostRequest() {
+        Map<String, String> params = new HashMap<>();
+        params.put("foo", "bar");
+        OAuthRequest request = OAuthUtilities.buildNormalPostRequest(params, "http://foo");
+        List<Parameter> bodyParams = request.getBodyParams().getParams();
+        assertEquals(1, bodyParams.size());
+        assertEquals(new Parameter("foo", "bar"), bodyParams.get(0));
+    }
+
+    @Test
+    public void testBuildMultipartRequest() {
+        Map<String, String> params = new HashMap<>();
+        params.put("foo", "bar");
+        OAuthRequest request = OAuthUtilities.buildMultipartRequest(params, "http://foo");
+        List<Parameter> queryStringParams = request.getQueryStringParams().getParams();
+        assertEquals(1, queryStringParams.size());
+        assertEquals(new Parameter("foo", "bar"), queryStringParams.get(0));
+        String contentType = request.getHeaders().get("Content-Type");
+        assertTrue(contentType, contentType.matches(
+                "multipart/form-data; boundary=---------------------------[a-f0-9]{8}(-[a-f0-9]{4}){4}[a-f0-9]{8}"));
+    }
+}

--- a/src/test/java/com/flickr4java/flickr/test/PhotosInterfaceTest.java
+++ b/src/test/java/com/flickr4java/flickr/test/PhotosInterfaceTest.java
@@ -197,7 +197,6 @@ public class PhotosInterfaceTest extends Flickr4JavaTest {
 
         // Find number of existing tags
         int preCount = photo.getTags().size();
-        int postCount = preCount + 1;
 
         // Add a tag
         String[] tagsToAdd = { "test" };

--- a/src/test/java/com/flickr4java/flickr/test/util/FileTestProperties.java
+++ b/src/test/java/com/flickr4java/flickr/test/util/FileTestProperties.java
@@ -1,8 +1,6 @@
 package com.flickr4java.flickr.test.util;
 
 import com.flickr4java.flickr.FlickrRuntimeException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -19,11 +17,6 @@ import java.util.Properties;
  * @author Darren Greaves Copyright (c) 2012 Darren Greaves.
  */
 public class FileTestProperties implements TestProperties {
-
-    /**
-     * Logger.
-     */
-    private static Logger _log = LoggerFactory.getLogger(FileTestProperties.class);
 
     private String host;
 

--- a/src/test/java/com/flickr4java/flickr/test/util/TransportStub.java
+++ b/src/test/java/com/flickr4java/flickr/test/util/TransportStub.java
@@ -4,8 +4,6 @@ import com.flickr4java.flickr.*;
 import com.flickr4java.flickr.uploader.Payload;
 import com.flickr4java.flickr.uploader.UploadMetaData;
 import com.flickr4java.flickr.uploader.UploaderResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
@@ -17,12 +15,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashMap;
 import java.util.Map;
 
 public class TransportStub extends Transport {
-
-    private static final Logger _log = LoggerFactory.getLogger(TransportStub.class);
 
     private final DocumentBuilder builder;
 


### PR DESCRIPTION
The objective of this PR is to upgrade to the latest version of Scribe, I also updated other dependencies and Maven plugins, requiring to fix Javadoc errors.

The Scribe API has changed:
* `initMultipartBoundary(String boundary)` has been replaced by `initMultipartPayload(String boundary)`
* `addMultipartPayload(String contentDisposition, String contentType, byte[] payload)` has been replaced by `addFileByteArrayBodyPartPayloadInMultipartPayload(String contentType, byte[] fileContent)`

I refactored the OAuth code a bit to write more unit tests but **I couldn't test for real** the multipart upload. Can you please give me some advice on this?