### PR TITLE
Deprecate lookupUser. New method to return a User instead of username

### DIFF
--- a/src/main/java/com/flickr4java/flickr/urls/UrlsInterface.java
+++ b/src/main/java/com/flickr4java/flickr/urls/UrlsInterface.java
@@ -152,13 +152,39 @@ public class UrlsInterface {
 
     /**
      * Lookup the username for the specified User URL.
-     * 
+     *
      * @param url
      *            The user profile URL
      * @return The username
      * @throws FlickrException if there was a problem connecting to Flickr
      */
+    public String lookupUsernameByURL(String url) throws FlickrException {
+        return lookupUserByURL(url).getUsername();
+    }
+
+    /**
+     * Lookup the username for the specified User URL.
+     * 
+     * @param url
+     *            The user profile URL
+     * @return The username
+     * @throws FlickrException if there was a problem connecting to Flickr
+     * @deprecated use {@link #lookupUsernameByURL(String) }
+     */
+    @Deprecated
     public String lookupUser(String url) throws FlickrException {
+        return lookupUsernameByURL(url);
+    }
+
+    /**
+     * Lookup the user for the specified User URL.
+     *
+     * @param url
+     *            The user profile URL
+     * @return The user
+     * @throws FlickrException if there was a problem connecting to Flickr
+     */
+    public User lookupUserByURL(String url) throws FlickrException {
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("method", METHOD_LOOKUP_USER);
 
@@ -171,7 +197,10 @@ public class UrlsInterface {
 
         Element payload = response.getPayload();
         Element groupnameElement = (Element) payload.getElementsByTagName("username").item(0);
-        return ((Text) groupnameElement.getFirstChild()).getData();
+        User user = new User();
+        user.setId(payload.getAttribute("id"));
+        user.setUsername(((Text) groupnameElement.getFirstChild()).getData());
+        return user;
     }
 
     /**

--- a/src/test/java/com/flickr4java/flickr/test/UrlsInterfaceTest.java
+++ b/src/test/java/com/flickr4java/flickr/test/UrlsInterfaceTest.java
@@ -56,10 +56,10 @@ public class UrlsInterfaceTest extends Flickr4JavaTest {
     }
 
     @Test
-    public void testLookupUser() throws FlickrException {
+    public void testLookupUsernameByURL() throws FlickrException {
         UrlsInterface iface = flickr.getUrlsInterface();
         String username = testProperties.getUsername();
-        String usernameOnFlickr = iface.lookupUser(String.format("https://www.flickr.com/people/%s/", username));
+        String usernameOnFlickr = iface.lookupUsernameByURL(String.format("https://www.flickr.com/people/%s/", username));
         assertEquals(username, usernameOnFlickr);
     }
 


### PR DESCRIPTION
This allows to find user id from an URL