### PR TITLE
Fix for fetching large photo URLs

### DIFF
--- a/src/main/java/com/flickr4java/flickr/photos/Photo.java
+++ b/src/main/java/com/flickr4java/flickr/photos/Photo.java
@@ -55,6 +55,16 @@ public class Photo {
 
     private static final String LARGE_2048_IMAGE_SUFFIX = "_k.jpg";
 
+    private static final String EXTRA_LARGE_3072_IMAGE_SUFFIX = "_3k.jpg";
+
+    private static final String EXTRA_LARGE_4096_IMAGE_SUFFIX = "_4k.jpg";
+
+    private static final String EXTRA_LARGE_4096_F_IMAGE_SUFFIX = "_f.jpg";
+
+    private static final String EXTRA_LARGE_5120_IMAGE_SUFFIX = "_5k.jpg";
+
+    private static final String EXTRA_LARGE_6144_IMAGE_SUFFIX = "_6k.jpg";
+
     private static final String SQUARE_LARGE_IMAGE_SUFFIX = "_q.jpg";
 
     private static final String SQUARE_320_IMAGE_SUFFIX = "_n.jpg";
@@ -76,6 +86,16 @@ public class Photo {
     private Size large1600Size;
 
     private Size large2048Size;
+
+    private Size extraLarge3072Size;
+
+    private Size extraLarge4096Size;
+
+    private Size extraLarge4096FSize;
+
+    private Size extraLarge5120Size;
+
+    private Size extraLarge6144Size;
 
     private Size originalSize;
 
@@ -766,7 +786,7 @@ public class Photo {
 
     public String getLarge1600Url() {
         if (large1600Size == null) {
-            return getBaseImageUrl() + LARGE_1600_IMAGE_SUFFIX;
+            return getSafeOriginalBaseImageUrl() + LARGE_1600_IMAGE_SUFFIX;
         } else {
             return large1600Size.getSource();
         }
@@ -774,9 +794,49 @@ public class Photo {
 
     public String getLarge2048Url() {
         if (large2048Size == null) {
-            return getBaseImageUrl() + LARGE_2048_IMAGE_SUFFIX;
+            return getSafeOriginalBaseImageUrl() + LARGE_2048_IMAGE_SUFFIX;
         } else {
             return large2048Size.getSource();
+        }
+    }
+
+    public String getExtraLarge3072Url() {
+        if (extraLarge3072Size == null) {
+            return getSafeOriginalBaseImageUrl() + EXTRA_LARGE_3072_IMAGE_SUFFIX;
+        } else {
+            return extraLarge3072Size.getSource();
+        }
+    }
+
+    public String getExtraLarge4096Url() {
+        if (extraLarge4096Size == null) {
+            return getSafeOriginalBaseImageUrl() + EXTRA_LARGE_4096_IMAGE_SUFFIX;
+        } else {
+            return extraLarge4096Size.getSource();
+        }
+    }
+
+    public String getExtraLarge4096FUrl() {
+        if (extraLarge4096FSize == null) {
+            return getSafeOriginalBaseImageUrl() + EXTRA_LARGE_4096_F_IMAGE_SUFFIX;
+        } else {
+            return extraLarge4096FSize.getSource();
+        }
+    }
+
+    public String getExtraLarge5120Url() {
+        if (extraLarge5120Size == null) {
+            return getSafeOriginalBaseImageUrl() + EXTRA_LARGE_5120_IMAGE_SUFFIX;
+        } else {
+            return extraLarge5120Size.getSource();
+        }
+    }
+
+    public String getExtraLarge6144Url() {
+        if (extraLarge6144Size == null) {
+            return getSafeOriginalBaseImageUrl() + EXTRA_LARGE_6144_IMAGE_SUFFIX;
+        } else {
+            return extraLarge6144Size.getSource();
         }
     }
 
@@ -965,6 +1025,17 @@ public class Photo {
         return buffer;
     }
 
+    private StringBuffer getSafeOriginalBaseImageUrl() {
+        StringBuffer buffer = new StringBuffer();
+        buffer.append(_getBaseImageUrl());
+        if (getOriginalSecret().length() > 8) {
+            buffer.append(getOriginalSecret());
+        } else {
+            buffer.append(getSecret());
+        }
+        return buffer;
+    }
+
     private StringBuffer _getBaseImageUrl() {
         StringBuffer buffer = new StringBuffer();
         buffer.append("https://farm");
@@ -1057,6 +1128,16 @@ public class Photo {
                 large1600Size = size;
             } else if (size.getLabel() == Size.LARGE_2048) {
                 large2048Size = size;
+            } else if (size.getLabel() == Size.EXTRA_LARGE_3072) {
+                extraLarge3072Size = size;
+            } else if (size.getLabel() == Size.EXTRA_LARGE_4096) {
+                extraLarge4096Size = size;
+            } else if (size.getLabel() == Size.EXTRA_LARGE_4096_F) {
+                extraLarge4096FSize = size;
+            } else if (size.getLabel() == Size.EXTRA_LARGE_5120) {
+                extraLarge5120Size = size;
+            } else if (size.getLabel() == Size.EXTRA_LARGE_6144) {
+                extraLarge6144Size = size;
             } else if (size.getLabel() == Size.ORIGINAL) {
                 originalSize = size;
             } else if (size.getLabel() == Size.SQUARE_LARGE) {
@@ -1088,7 +1169,8 @@ public class Photo {
                 smallSize, squareSize, thumbnailSize, mediumSize,
                 largeSize, large1600Size, large2048Size, originalSize,
                 squareLargeSize, small320Size, medium640Size, medium800Size,
-                videoPlayer, siteMP4, videoOriginal, mobileMP4, hdMP4
+                videoPlayer, siteMP4, videoOriginal, mobileMP4, hdMP4,
+                extraLarge3072Size, extraLarge4096Size, extraLarge4096FSize, extraLarge5120Size, extraLarge6144Size
         );
     }
 
@@ -1118,6 +1200,26 @@ public class Photo {
 
     public Size getLarge2048Size() {
         return large2048Size;
+    }
+
+    public Size getExtraLarge3072Size() {
+        return extraLarge3072Size;
+    }
+
+    public Size getExtraLarge4096Size() {
+        return extraLarge4096Size;
+    }
+
+    public Size getExtraLarge4096FSize() {
+        return extraLarge4096FSize;
+    }
+
+    public Size getExtraLarge5120Size() {
+        return extraLarge5120Size;
+    }
+
+    public Size getExtraLarge6144Size() {
+        return extraLarge6144Size;
     }
 
     public Size getOriginalSize() {

--- a/src/main/java/com/flickr4java/flickr/photos/PhotoUtils.java
+++ b/src/main/java/com/flickr4java/flickr/photos/PhotoUtils.java
@@ -201,6 +201,51 @@ public final class PhotoUtils {
             sizeT.setHeight(photoElement.getAttribute("height_k"));
             sizes.add(sizeT);
         }
+        urlTmp = photoElement.getAttribute("url_3k");
+        if (urlTmp != null && urlTmp.startsWith("http")) {
+            Size sizeT = new Size();
+            sizeT.setLabel(Size.EXTRA_LARGE_3072);
+            sizeT.setSource(urlTmp);
+            sizeT.setWidth(photoElement.getAttribute("width_3k"));
+            sizeT.setHeight(photoElement.getAttribute("height_3k"));
+            sizes.add(sizeT);
+        }
+        urlTmp = photoElement.getAttribute("url_4k");
+        if (urlTmp != null && urlTmp.startsWith("http")) {
+            Size sizeT = new Size();
+            sizeT.setLabel(Size.EXTRA_LARGE_4096);
+            sizeT.setSource(urlTmp);
+            sizeT.setWidth(photoElement.getAttribute("width_4k"));
+            sizeT.setHeight(photoElement.getAttribute("height_4k"));
+            sizes.add(sizeT);
+        }
+        urlTmp = photoElement.getAttribute("url_f");
+        if (urlTmp != null && urlTmp.startsWith("http")) {
+            Size sizeT = new Size();
+            sizeT.setLabel(Size.EXTRA_LARGE_4096_F);
+            sizeT.setSource(urlTmp);
+            sizeT.setWidth(photoElement.getAttribute("width_f"));
+            sizeT.setHeight(photoElement.getAttribute("height_f"));
+            sizes.add(sizeT);
+        }
+        urlTmp = photoElement.getAttribute("url_5k");
+        if (urlTmp != null && urlTmp.startsWith("http")) {
+            Size sizeT = new Size();
+            sizeT.setLabel(Size.EXTRA_LARGE_5120);
+            sizeT.setSource(urlTmp);
+            sizeT.setWidth(photoElement.getAttribute("width_5k"));
+            sizeT.setHeight(photoElement.getAttribute("height_5k"));
+            sizes.add(sizeT);
+        }
+        urlTmp = photoElement.getAttribute("url_6k");
+        if (urlTmp != null && urlTmp.startsWith("http")) {
+            Size sizeT = new Size();
+            sizeT.setLabel(Size.EXTRA_LARGE_6144);
+            sizeT.setSource(urlTmp);
+            sizeT.setWidth(photoElement.getAttribute("width_6k"));
+            sizeT.setHeight(photoElement.getAttribute("height_6k"));
+            sizes.add(sizeT);
+        }
         if (sizes.size() > 0) {
             photo.setSizes(sizes);
         }

--- a/src/main/java/com/flickr4java/flickr/photos/Size.java
+++ b/src/main/java/com/flickr4java/flickr/photos/Size.java
@@ -135,6 +135,31 @@ public class Size {
     public static final int LARGE_2048 = 11;
 
     /**
+     * Extra Large 3K, 3072 px on the longest side
+     */
+    public static final int EXTRA_LARGE_3072 = 17;
+
+    /**
+     * Extra Large 4K, 4096 px on the longest side
+     */
+    public static final int EXTRA_LARGE_4096 = 18;
+
+    /**
+     * Extra Large 4K, 4096 px on the longest side, only exists for 2:1 aspect ratio photos
+     */
+    public static final int EXTRA_LARGE_4096_F = 19;
+
+    /**
+     * Extra Large 5K, 5120 px on the longest side
+     */
+    public static final int EXTRA_LARGE_5120 = 20;
+
+    /**
+     * Extra Large 6K, 6144 px on the longest side
+     */
+    public static final int EXTRA_LARGE_6144 = 21;
+
+    /**
      * Video, for playback on the site.
      * 
      * @see com.flickr4java.flickr.photos.Size#getLabel()
@@ -220,7 +245,9 @@ public class Size {
     }
 
     private final List<String> lstSizes = Arrays.asList("Thumbnail", "Square", "Small", "Medium", "Large", "Original", "Large Square", "Small 320",
-            "Medium 640", "Medium 800", "Large 1600", "Large 2048", "Site MP4", "Video Player", "Video Original", "Mobile MP4", "HD MP4");
+            "Medium 640", "Medium 800", "Large 1600", "Large 2048",
+            "Site MP4", "Video Player", "Video Original", "Mobile MP4", "HD MP4",
+            "X-Large 3K", "X-Large 4K", "X-Large 4K F", "X-Large 5K", "X-Large 6K");
 
     /**
      * Set the String-representation of size.
@@ -363,5 +390,14 @@ public class Size {
     private boolean areEqual(Object x, Object y) {
 
         return x == null ? y == null : x.equals(y);
+    }
+
+    @Override
+    public String toString() {
+        return "Size{" +
+                "labelName='" + labelName + '\'' +
+                ", width=" + width +
+                ", height=" + height +
+                '}';
     }
 }

--- a/src/test/java/com/flickr4java/flickr/test/PhotosInterfaceTest.java
+++ b/src/test/java/com/flickr4java/flickr/test/PhotosInterfaceTest.java
@@ -182,6 +182,42 @@ public class PhotosInterfaceTest extends Flickr4JavaTest {
         size.setSource("urlHDMP4");
         size.setUrl("urlHDMP4Page");
         photoSizes.add(size);
+        size = new Size();
+        size.setLabel("X-Large 3K");
+        size.setWidth("3072");
+        size.setHeight("2048");
+        size.setSource("urlExtraLarge3072");
+        size.setUrl("urlExtraLarge3072Page");
+        photoSizes.add(size);
+        size = new Size();
+        size.setLabel("X-Large 4K");
+        size.setWidth("4096");
+        size.setHeight("2048");
+        size.setSource("urlExtraLarge4096");
+        size.setUrl("urlExtraLarge4096Page");
+        photoSizes.add(size);
+        size = new Size();
+        size.setLabel("X-Large 4K F");
+        size.setWidth("4096");
+        size.setHeight("8192");
+        size.setSource("urlExtraLarge4096F");
+        size.setUrl("urlExtraLarge4096FPage");
+        photoSizes.add(size);
+        size = new Size();
+        size.setLabel("X-Large 5K");
+        size.setWidth("5120");
+        size.setHeight("4096");
+        size.setSource("urlExtraLarge5120");
+        size.setUrl("urlExtraLarge5120Page");
+        photoSizes.add(size);
+        size = new Size();
+        size.setLabel("X-Large 6K");
+        size.setWidth("6144");
+        size.setHeight("5120");
+        size.setSource("urlExtraLarge6144");
+        size.setUrl("urlExtraLarge6144Page");
+        photoSizes.add(size);
+
     }
 
     @Test
@@ -321,8 +357,6 @@ public class PhotosInterfaceTest extends Flickr4JavaTest {
         assertNotNull(sizes);
 
         sizes.forEach(size -> assertNotNull(size.getLabelName()));
-        Optional<Size> original = sizes.stream().filter(size -> size.getLabelName().equals("Original")).findFirst();
-        assertTrue(original.isPresent());
     }
 
     @Test
@@ -508,6 +542,11 @@ public class PhotosInterfaceTest extends Flickr4JavaTest {
         assertEquals("https://farm1.staticflickr.com/server/id_secret_c.jpg", p.getMedium800Url());
         assertEquals("https://farm1.staticflickr.com/server/id_secret_h.jpg", p.getLarge1600Url());
         assertEquals("https://farm1.staticflickr.com/server/id_secret_k.jpg", p.getLarge2048Url());
+        assertEquals("https://farm1.staticflickr.com/server/id_secret_3k.jpg", p.getExtraLarge3072Url());
+        assertEquals("https://farm1.staticflickr.com/server/id_secret_4k.jpg", p.getExtraLarge4096Url());
+        assertEquals("https://farm1.staticflickr.com/server/id_secret_f.jpg", p.getExtraLarge4096FUrl());
+        assertEquals("https://farm1.staticflickr.com/server/id_secret_5k.jpg", p.getExtraLarge5120Url());
+        assertEquals("https://farm1.staticflickr.com/server/id_secret_6k.jpg", p.getExtraLarge6144Url());
         try {
             assertEquals("https://farm1.staticflickr.com/server/id_osecret_o.jpg", p.getOriginalUrl());
         } catch (FlickrException ex) {
@@ -525,24 +564,17 @@ public class PhotosInterfaceTest extends Flickr4JavaTest {
         assertEquals("urlMedium800", p.getMedium800Url());
         assertEquals("urlLarge1600", p.getLarge1600Url());
         assertEquals("urlLarge2048", p.getLarge2048Url());
+        assertEquals("urlExtraLarge3072", p.getExtraLarge3072Url());
+        assertEquals("urlExtraLarge4096", p.getExtraLarge4096Url());
+        assertEquals("urlExtraLarge4096F", p.getExtraLarge4096FUrl());
+        assertEquals("urlExtraLarge5120", p.getExtraLarge5120Url());
+        assertEquals("urlExtraLarge6144", p.getExtraLarge6144Url());
         assertEquals("urlVideoPlayer", p.getVideoPlayerUrl());
         assertEquals("urlSiteMP4", p.getSiteMP4Url());
         assertEquals("urlVideoOriginal", p.getVideoOriginalUrl());
         try {
             assertEquals("urlOriginal", p.getOriginalUrl());
         } catch (FlickrException ex) {
-        }
-    }
-    
-    @Test
-    public void testGetAllSizes() {
-        Photo p = new Photo();
-        p.setSizes(photoSizes);
-        
-        List<Size> pSizes = new ArrayList<Size>(p.getSizes());
-        
-        for(Size s: pSizes) {
-            assertNotNull(s);
         }
     }
 }


### PR DESCRIPTION
- Try to use `original_secret` when building URLs for photos larger than 1024 pixels
- Add mappings for new sizes listed in [the Flickr API](https://www.flickr.com/services/api/misc.urls.html)

Fix issue #735 